### PR TITLE
Pytest: Creating an organization fails

### DIFF
--- a/src/core/core/model/organization.py
+++ b/src/core/core/model/organization.py
@@ -22,8 +22,8 @@ class Organization(db.Model):
     address_id = db.Column(db.Integer, db.ForeignKey("address.id"))
     address = db.relationship("Address", cascade="all")
 
-    def __init__(self, name, description, address):
-        self.id = None
+    def __init__(self, name, description, address, id=None):
+        self.id = id
         self.name = name
         self.description = description
         self.address = address


### PR DESCRIPTION
Creating an organization with an id throws the following error:

"TypeError: __init__() got an unexpected keyword argument 'id'"

This occurs because the organization model doesn't have an parameter for id.


Fixes #

## Changes



## Make sure to check points below to increase likelyhood of your pull request being accepted:

- [x] I have updated the documentation
- [x] I have added tests to cover my changes
- [x] I checked if all new and existing tests passed
- [x] I checked if I followed standards for style and code quality
- [x] I created an Issue describing why this change is necessary
